### PR TITLE
CI(security): harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,14 +14,7 @@ on:
     paths-ignore:
       - '**.md'
 
-permissions:
-  # required for all workflows
-  security-events: write
-  # required to fetch internal or private CodeQL packs
-  packages: read
-  # only required for workflows in private repositories
-  actions: read
-  contents: read
+permissions: {}
 
 jobs:
   analyze:
@@ -33,6 +26,14 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,15 @@ on:
     paths-ignore:
       - '**.md'
 
+permissions:
+  # required for all workflows
+  security-events: write
+  # required to fetch internal or private CodeQL packs
+  packages: read
+  # only required for workflows in private repositories
+  actions: read
+  contents: read
+
 jobs:
   analyze:
     if: github.repository == 'fluttercandies/flutter_wechat_picker_library'
@@ -24,14 +33,6 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    permissions:
-      # required for all workflows
-      security-events: write
-      # required to fetch internal or private CodeQL packs
-      packages: read
-      # only required for workflows in private repositories
-      actions: read
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +50,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@900f2210b1d28bbbd0bd22d17926b9e224e8f231
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - name: Publish
         uses: k-paxian/dart-package-publisher@8fdba1dbf624c712706281a6f91cb50b6bfc2eaf
         with:

--- a/.github/workflows/publishable.yml
+++ b/.github/workflows/publishable.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: k-paxian/dart-package-publisher@8fdba1dbf624c712706281a6f91cb50b6bfc2eaf
         with:
           credentialJson: 'MockCredentialJson'

--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -30,6 +30,8 @@ jobs:
         flutter-version: [ min, latest ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
         with:
           distribution: 'zulu'


### PR DESCRIPTION
Hardens the `.github/workflows/` files to resolve the zizmor findings reported in fluttercandies/security-scanner#10.

## Changes

### `codeql.yml`
- **excessive-permissions (Medium)**: hoisted the `permissions:` block (`security-events: write`, `packages: read`, `actions: read`, `contents: read`) from the single `analyze` job to workflow level, placing it right after `on:` and before `jobs:`. With a single job this is safe and silences the missing workflow-level permissions finding.
- **artipacked (Medium)**: added `persist-credentials: false` to the `actions/checkout` step.

### `publish.yml`
- **artipacked (Low)**: added `persist-credentials: false` to the `actions/checkout` step.

### `publishable.yml`
- **artipacked (Low)**: added `persist-credentials: false` to the `actions/checkout` step.

### `runnable.yml`
- **artipacked (Low)**: added `persist-credentials: false` to the `actions/checkout` step.

All `actions/checkout` steps in these workflows now set `persist-credentials: false`. None of these workflows push back via git using the checkout's own token, so this is safe.

## Not addressed
- **stale-action-refs (Low)**: `actions/checkout@900f2210…` in `codeql.yml` and `flutter-actions/setup-flutter@18c66a64…` in `runnable.yml`. These are already pinned to commit SHAs — the secure pattern — and the Low finding only notes the SHA does not resolve to a release tag, which is not a security defect. Left as-is.

Resolves zizmor findings in fluttercandies/security-scanner#10.